### PR TITLE
Create a Delivery Http client

### DIFF
--- a/Kentico.Kontent.Delivery.Abstractions/IDeliveryHttpClient.cs
+++ b/Kentico.Kontent.Delivery.Abstractions/IDeliveryHttpClient.cs
@@ -1,0 +1,18 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Kentico.Kontent.Delivery.Abstractions
+{
+    /// <summary>
+    /// Represents a requests operations against Kentico Kontent Delivery API.
+    /// </summary>
+    public interface IDeliveryHttpClient
+    {
+        /// <summary>
+        /// Returns a response message from Kentico Kontent Delivery API.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        Task<HttpResponseMessage> SendHttpMessageAsync(HttpRequestMessage message);
+    }
+}

--- a/Kentico.Kontent.Delivery.Rx.Tests/DeliveryObservableProxyTests.cs
+++ b/Kentico.Kontent.Delivery.Rx.Tests/DeliveryObservableProxyTests.cs
@@ -251,7 +251,7 @@ namespace Kentico.Kontent.Delivery.Rx.Tests
         private IDeliveryClient GetDeliveryClient(Action mockAction)
         {
             mockAction();
-            var httpClient = mockHttp.ToHttpClient();
+            var deliveryHttpClient = new DeliveryHttpClient(mockHttp.ToHttpClient());
             var deliveryOptions = new OptionsWrapper<DeliveryOptions>(new DeliveryOptions { ProjectId = guid });
             var contentLinkUrlResolver = A.Fake<IContentLinkUrlResolver>();
             var contentLinkResolver = new ContentLinkResolver(contentLinkUrlResolver);
@@ -266,12 +266,13 @@ namespace Kentico.Kontent.Delivery.Rx.Tests
                 .ReturnsLazily(call => call.GetArgument<Func<Task<HttpResponseMessage>>>(0)());
             var client = new DeliveryClient(
                 deliveryOptions,
-                httpClient,
                 contentLinkResolver, 
                 null,
                 modelProvider,
                 retryPolicyProvider,
-                contentTypeProvider
+                contentTypeProvider,
+                null,
+                deliveryHttpClient
             );
 
             return client;

--- a/Kentico.Kontent.Delivery.Rx/Kentico.Kontent.Delivery.Rx.csproj
+++ b/Kentico.Kontent.Delivery.Rx/Kentico.Kontent.Delivery.Rx.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Kentico.Kontent.Delivery.Abstractions\Kentico.Kontent.Delivery.Abstractions.csproj" />
     <ProjectReference Include="..\Kentico.Kontent.Delivery\Kentico.Kontent.Delivery.csproj" />
   </ItemGroup>
 

--- a/Kentico.Kontent.Delivery.Tests/Builders/DeliveryClient/DeliveryClientBuilderTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/Builders/DeliveryClient/DeliveryClientBuilderTests.cs
@@ -61,11 +61,11 @@ namespace Kentico.Kontent.Delivery.Tests.Builders.DeliveryClient
             var mockUnretrievedInlineContentItemsResolver = A.Fake<IInlineContentItemsResolver<UnretrievedContentItem>>();
             var mockAnContentItemsResolver = A.Fake<IInlineContentItemsResolver<CompleteContentItemModel>>();
             var mockTypeProvider = A.Fake<ITypeProvider>();
-            var mockHttp = new MockHttpMessageHandler().ToHttpClient();            
+            var mockDeliveryHttpClient = new DeliveryHttpClient(new MockHttpMessageHandler().ToHttpClient());
 
             var deliveryClient = (Delivery.DeliveryClient) DeliveryClientBuilder
                 .WithProjectId(ProjectId)
-                .WithHttpClient(mockHttp)
+                .WithDeliveryHttpClient(mockDeliveryHttpClient)
                 .WithContentLinkUrlResolver(mockContentLinkUrlResolver)
                 .WithInlineContentItemsProcessor(mockInlineContentItemsProcessor)
                 .WithInlineContentItemsResolver(mockDefaultInlineContentItemsResolver)
@@ -84,7 +84,7 @@ namespace Kentico.Kontent.Delivery.Tests.Builders.DeliveryClient
             Assert.Equal(mockPropertyMapper, deliveryClient.PropertyMapper);
             Assert.Equal(mockRetryPolicyProvider, deliveryClient.RetryPolicyProvider);
             Assert.Equal(mockTypeProvider, deliveryClient.TypeProvider);
-            Assert.Equal(mockHttp, deliveryClient.HttpClient);
+            Assert.Equal(mockDeliveryHttpClient, deliveryClient.DeliveryHttpClient);
         }
 
         [Fact]
@@ -145,7 +145,7 @@ namespace Kentico.Kontent.Delivery.Tests.Builders.DeliveryClient
             Assert.NotNull(deliveryClient.PropertyMapper);
             Assert.NotNull(deliveryClient.TypeProvider);
             Assert.NotNull(deliveryClient.ContentLinkResolver);
-            Assert.NotNull(deliveryClient.HttpClient);
+            Assert.NotNull(deliveryClient.DeliveryHttpClient);
             Assert.NotNull(deliveryClient.InlineContentItemsProcessor);
             Assert.NotNull(deliveryClient.RetryPolicyProvider);
             Assert.Equal(expectedResolvableInlineContentItemsTypes, actualResolvableInlineContentItemTypes);
@@ -156,7 +156,7 @@ namespace Kentico.Kontent.Delivery.Tests.Builders.DeliveryClient
         {
             var builderStep = DeliveryClientBuilder.WithProjectId(_guid);
 
-            Assert.Throws<ArgumentNullException>(() => builderStep.WithHttpClient(null));
+            Assert.Throws<ArgumentNullException>(() => builderStep.WithDeliveryHttpClient(null));
         }
 
         [Fact]

--- a/Kentico.Kontent.Delivery.Tests/ContentLinkResolverTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/ContentLinkResolverTests.cs
@@ -125,7 +125,7 @@ namespace Kentico.Kontent.Delivery.Tests
                Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}ContentLinkResolver{Path.DirectorySeparatorChar}coffee_processing_techniques.json")));
 
             var deliveryOptions = Options.Create(new DeliveryOptions { ProjectId = guid });
-            var httpClient = mockHttp.ToHttpClient();
+            var deliveryHttpClient = new DeliveryHttpClient(mockHttp.ToHttpClient());
             var resiliencePolicyProvider = new DefaultRetryPolicyProvider(deliveryOptions);
             var contentLinkUrlResolver = new CustomContentLinkUrlResolver();
             var contentLinkResolver = new ContentLinkResolver(contentLinkUrlResolver);
@@ -133,11 +133,13 @@ namespace Kentico.Kontent.Delivery.Tests
             var modelProvider= new ModelProvider(contentLinkResolver, contentItemsProcessor, new CustomTypeProvider(), new PropertyMapper());
             var client = new DeliveryClient(
                 deliveryOptions,
-                httpClient,
                 contentLinkResolver,
                 contentItemsProcessor,
                 modelProvider,
-                resiliencePolicyProvider
+                resiliencePolicyProvider,
+                null,
+                null,
+                deliveryHttpClient
             );
 
 

--- a/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
@@ -1333,7 +1333,7 @@ namespace Kentico.Kontent.Delivery.Tests
                 .WithInlineContentItemsResolver(InlineContentItemsResolverFactory.Instance
                     .ResolveTo<HostedVideo>(video => hostedVideoPrefix + video.VideoHost.First().Name))
                 .WithTypeProvider(new CustomTypeProvider())
-                .WithHttpClient(_mockHttp.ToHttpClient())
+                .WithDeliveryHttpClient(new DeliveryHttpClient(_mockHttp.ToHttpClient()))
                 .Build();
 
             var article = await deliveryClient.GetItemAsync<Article>("coffee_beverages_explained");

--- a/Kentico.Kontent.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
@@ -46,7 +46,7 @@ namespace Kentico.Kontent.Delivery.Tests.Extensions
                 { typeof(IContentLinkUrlResolver), typeof(DefaultContentLinkUrlResolver) },
                 { typeof(IContentLinkResolver), typeof(ContentLinkResolver) },
                 { typeof(ITypeProvider), typeof(TypeProvider) },
-                { typeof(HttpClient), typeof(HttpClient) },
+                { typeof(IDeliveryHttpClient), typeof(DeliveryHttpClient) },
                 { typeof(IInlineContentItemsProcessor), typeof(InlineContentItemsProcessor) },
                 { typeof(IInlineContentItemsResolver<object>), typeof(ReplaceWithWarningAboutRegistrationResolver) },
                 { typeof(IInlineContentItemsResolver<UnretrievedContentItem>), typeof(ReplaceWithWarningAboutUnretrievedItemResolver) },
@@ -54,7 +54,7 @@ namespace Kentico.Kontent.Delivery.Tests.Extensions
                 { typeof(IModelProvider), typeof(ModelProvider) },
                 { typeof(IPropertyMapper), typeof(PropertyMapper) },
                 { typeof(IRetryPolicyProvider), typeof(DefaultRetryPolicyProvider) },
-                { typeof(IDeliveryClient), typeof(DeliveryClient) }
+                { typeof(IDeliveryClient), typeof(DeliveryClient) },
             }
         );
 

--- a/Kentico.Kontent.Delivery.Tests/Factories/DeliveryClientFactory.cs
+++ b/Kentico.Kontent.Delivery.Tests/Factories/DeliveryClientFactory.cs
@@ -42,13 +42,13 @@ namespace Kentico.Kontent.Delivery.Tests.Factories
 
             var client = new DeliveryClient(
                 Options.Create(new DeliveryOptions { ProjectId = projectId.ToString() }),
-                httpClient,
                 new ContentLinkResolver(_mockContentLinkUrlResolver),
                 _mockInlineContentItemsProcessor,
                 _mockModelProvider,
                 _mockResiliencePolicyProvider,
                 _mockTypeProvider,
-                _mockPropertyMapper
+                _mockPropertyMapper,
+                new DeliveryHttpClient(httpClient)
             );
 
             return client;
@@ -56,16 +56,16 @@ namespace Kentico.Kontent.Delivery.Tests.Factories
 
         internal static DeliveryClient GetMockedDeliveryClientWithOptions(DeliveryOptions options, MockHttpMessageHandler httpMessageHandler = null)
         {
-            var httpClient = httpMessageHandler != null ? httpMessageHandler.ToHttpClient() : MockHttp.ToHttpClient();
+            var deliveryHttpClient = new DeliveryHttpClient(httpMessageHandler != null ? httpMessageHandler.ToHttpClient() : MockHttp.ToHttpClient());
             var client = new DeliveryClient(
                 Options.Create(options),
-                httpClient,
                 new ContentLinkResolver(_mockContentLinkUrlResolver),
                 _mockInlineContentItemsProcessor,
                 _mockModelProvider,
                 _mockResiliencePolicyProvider,
                 _mockTypeProvider,
-                _mockPropertyMapper
+                _mockPropertyMapper,
+                deliveryHttpClient
             );
 
             return client;

--- a/Kentico.Kontent.Delivery.Tests/FakeHttpClientTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/FakeHttpClientTests.cs
@@ -20,9 +20,9 @@ namespace Kentico.Kontent.Delivery.Tests
         {
             // Arrange
             const string testUrl = "https://tests.fake.url";
-            var httpClient = MockHttpClient(testUrl);
             var deliveryOptions = MockDeliveryOptions(testUrl);
-            var deliveryClient = MockDeliveryClient(deliveryOptions, httpClient);
+            var deliveryHttpClient = new DeliveryHttpClient(MockHttpClient(testUrl));
+            var deliveryClient = MockDeliveryClient(deliveryOptions, deliveryHttpClient);
 
             // Act
             var contentItem = await deliveryClient.GetItemAsync("test");
@@ -50,12 +50,13 @@ namespace Kentico.Kontent.Delivery.Tests
                 .WithCustomEndpoint($"{baseUrl}/{{0}}")
                 .Build();
 
-        private static IDeliveryClient MockDeliveryClient(DeliveryOptions deliveryOptions, HttpClient httpClient)
+        private static IDeliveryClient MockDeliveryClient(DeliveryOptions deliveryOptions, IDeliveryHttpClient deliveryHttpClient)
         {
             var contentLinkUrlResolver = A.Fake<IContentLinkUrlResolver>();
             var modelProvider = A.Fake<IModelProvider>();
             var retryPolicy = A.Fake<IRetryPolicy>();
             var retryPolicyProvider = A.Fake<IRetryPolicyProvider>();
+          
             A.CallTo(() => retryPolicyProvider.GetRetryPolicy())
                 .Returns(retryPolicy);
             A.CallTo(() => retryPolicy.ExecuteAsync(A<Func<Task<HttpResponseMessage>>>._))
@@ -63,7 +64,7 @@ namespace Kentico.Kontent.Delivery.Tests
 
             var client = DeliveryClientBuilder
                 .WithOptions(_ => deliveryOptions)
-                .WithHttpClient(httpClient)
+                .WithDeliveryHttpClient(deliveryHttpClient)
                 .WithContentLinkUrlResolver(contentLinkUrlResolver)
                 .WithModelProvider(modelProvider)
                 .WithRetryPolicyProvider(retryPolicyProvider)

--- a/Kentico.Kontent.Delivery.Tests/QueryParameters/ContentTypeExtractorTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/QueryParameters/ContentTypeExtractorTests.cs
@@ -28,7 +28,6 @@ namespace Kentico.Kontent.Delivery.Tests.QueryParameters
                 deliveryOptions,
                 null,
                 null,
-                null,
                 modelProvider,
                 null,
                 _contentTypeProvider

--- a/Kentico.Kontent.Delivery.Tests/ValueConverterTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/ValueConverterTests.cs
@@ -108,7 +108,7 @@ namespace Kentico.Kontent.Delivery.Tests
 
         private DeliveryClient InitializeDeliveryClient(MockHttpMessageHandler mockHttp)
         {
-            var httpClient = mockHttp.ToHttpClient();
+            var deliveryHttpClient = new DeliveryHttpClient(mockHttp.ToHttpClient());
             var contentLinkUrlResolver = A.Fake<IContentLinkUrlResolver>();
             var deliveryOptions = new OptionsWrapper<DeliveryOptions>(new DeliveryOptions { ProjectId = guid });
             var retryPolicy = A.Fake<IRetryPolicy>();
@@ -123,7 +123,7 @@ namespace Kentico.Kontent.Delivery.Tests
                 new CustomTypeProvider(),
                 new PropertyMapper()
             );
-            var client = new DeliveryClient(deliveryOptions, httpClient, null, null, modelProvider, retryPolicyProvider);
+            var client = new DeliveryClient(deliveryOptions, null, null, modelProvider, retryPolicyProvider, null, null, deliveryHttpClient);
 
             return client;
         }

--- a/Kentico.Kontent.Delivery/Builders/DeliveryClient/DeliveryClientBuilderImplementation.cs
+++ b/Kentico.Kontent.Delivery/Builders/DeliveryClient/DeliveryClientBuilderImplementation.cs
@@ -38,8 +38,8 @@ namespace Kentico.Kontent.Delivery.Builders.DeliveryClient
                     .UseProductionApi()
                     .Build());
 
-        IOptionalClientSetup IOptionalClientSetup.WithHttpClient(HttpClient httpClient)
-            => RegisterOrThrow(httpClient, nameof(httpClient));
+        IOptionalClientSetup IOptionalClientSetup.WithDeliveryHttpClient(IDeliveryHttpClient  deliveryHttpClient)
+            => RegisterOrThrow(deliveryHttpClient, nameof(deliveryHttpClient));
 
         IOptionalClientSetup IOptionalClientSetup.WithContentLinkUrlResolver(IContentLinkUrlResolver contentLinkUrlResolver)
             => RegisterOrThrow(contentLinkUrlResolver, nameof(contentLinkUrlResolver));

--- a/Kentico.Kontent.Delivery/Builders/DeliveryClient/IDeliveryClientBuilder.cs
+++ b/Kentico.Kontent.Delivery/Builders/DeliveryClient/IDeliveryClientBuilder.cs
@@ -30,10 +30,10 @@ namespace Kentico.Kontent.Delivery.Builders.DeliveryClient
     public interface IOptionalClientSetup : IDeliveryClientBuild
     {
         /// <summary>
-        /// Use a custom HTTP client.
+        /// Use a custom delivery HTTP client
         /// </summary>
-        /// <param name="httpClient">A custom HTTP client.</param>
-        IOptionalClientSetup WithHttpClient(HttpClient httpClient);
+        /// <param name="deliveryHttpClient">A custom <see cref="IDeliveryHttpClient"/> implementation</param>
+        IOptionalClientSetup WithDeliveryHttpClient(IDeliveryHttpClient deliveryHttpClient);
 
         /// <summary>
         /// Use a custom object to provide URL for content links in rich text elements.

--- a/Kentico.Kontent.Delivery/DeliveryClient.cs
+++ b/Kentico.Kontent.Delivery/DeliveryClient.cs
@@ -28,7 +28,7 @@ namespace Kentico.Kontent.Delivery
         internal readonly ITypeProvider TypeProvider;
         internal readonly IPropertyMapper PropertyMapper;
         internal readonly IRetryPolicyProvider RetryPolicyProvider;
-        internal readonly HttpClient HttpClient;
+        internal readonly IDeliveryHttpClient DeliveryHttpClient;
 
         private DeliveryEndpointUrlBuilder _urlBuilder;
 
@@ -39,32 +39,32 @@ namespace Kentico.Kontent.Delivery
         /// Initializes a new instance of the <see cref="DeliveryClient"/> class for retrieving content of the specified project.
         /// </summary>
         /// <param name="deliveryOptions">The settings of the Kentico Kontent project.</param>
-        /// <param name="httpClient">A custom HTTP client instance</param>
         /// <param name="contentLinkResolver">An instance of an object that can resolve links in rich text elements</param>
         /// <param name="contentItemsProcessor">An instance of an object that can resolve linked items in rich text elements</param>
         /// <param name="modelProvider">An instance of an object that can JSON responses into strongly typed CLR objects</param>
         /// <param name="retryPolicyProvider">A provider of a retry policy.</param>
         /// <param name="typeProvider">An instance of an object that can map Kentico Kontent content types to CLR types</param>
         /// <param name="propertyMapper">An instance of an object that can map Kentico Kontent content item fields to model properties</param>
+        /// <param name="deliveryHttpClient">An instance of an object that can send request againts Kentico Kontent Delivery API</param>
         public DeliveryClient(
             IOptions<DeliveryOptions> deliveryOptions,
-            HttpClient httpClient = null,
             IContentLinkResolver contentLinkResolver = null,
             IInlineContentItemsProcessor contentItemsProcessor = null,
             IModelProvider modelProvider = null,
             IRetryPolicyProvider retryPolicyProvider = null,
             ITypeProvider typeProvider = null,
-            IPropertyMapper propertyMapper = null
+            IPropertyMapper propertyMapper = null,
+            IDeliveryHttpClient deliveryHttpClient = null
         )
         {
             DeliveryOptions = deliveryOptions.Value;
-            HttpClient = httpClient;
             ContentLinkResolver = contentLinkResolver;
             InlineContentItemsProcessor = contentItemsProcessor;
             ModelProvider = modelProvider;
             RetryPolicyProvider = retryPolicyProvider;
             TypeProvider = typeProvider;
             PropertyMapper = propertyMapper;
+            DeliveryHttpClient = deliveryHttpClient;
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace Kentico.Kontent.Delivery
         /// <returns>The <see cref="DeliveryItemsFeed"/> instance that can be used to enumerate through content items. If no query parameters are specified, all content items are enumerated.</returns>
         public IDeliveryItemsFeed GetItemsFeed(params IQueryParameter[] parameters)
         {
-            return GetItemsFeed((IEnumerable<IQueryParameter>) parameters);
+            return GetItemsFeed((IEnumerable<IQueryParameter>)parameters);
         }
 
         /// <summary>
@@ -254,7 +254,7 @@ namespace Kentico.Kontent.Delivery
         /// <returns>The <see cref="DeliveryItemsFeed{T}"/> instance that can be used to enumerate through content items. If no query parameters are specified, all content items are enumerated.</returns>
         public IDeliveryItemsFeed<T> GetItemsFeed<T>(params IQueryParameter[] parameters)
         {
-            return GetItemsFeed<T>((IEnumerable<IQueryParameter>) parameters);
+            return GetItemsFeed<T>((IEnumerable<IQueryParameter>)parameters);
         }
 
         /// <summary>
@@ -518,7 +518,7 @@ namespace Kentico.Kontent.Delivery
                 message.Headers.AddContinuationHeader(continuationToken);
             }
 
-            return HttpClient.SendAsync(message);
+            return DeliveryHttpClient.SendHttpMessageAsync(message);
         }
 
         private bool UseSecureAccess()

--- a/Kentico.Kontent.Delivery/DeliveryHttpClient.cs
+++ b/Kentico.Kontent.Delivery/DeliveryHttpClient.cs
@@ -1,0 +1,34 @@
+﻿using Kentico.Kontent.Delivery.Abstractions;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Kentico.Kontent.Delivery
+{
+    /// <summary>
+    /// Executes Http requests against the Kentico Kontent Delivery API.
+    /// </summary>
+    public class DeliveryHttpClient : IDeliveryHttpClient
+    {
+        private readonly HttpClient _httpClient;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IDeliveryHttpClient"/> class.
+        /// </summary>
+        /// <param name="httpClient">Http client instance</param>
+        public DeliveryHttpClient(HttpClient httpClient = null)
+        {
+            _httpClient = httpClient ?? new HttpClient();
+        }
+
+        /// <summary>
+        /// Returns a response message from Kentico Kontent Delivery API.
+        /// </summary>
+        /// <param name="message">HttpRequestMessage instance represents the request message</param>
+        /// <returns></returns>
+        public async Task<HttpResponseMessage> SendHttpMessageAsync(HttpRequestMessage message)
+        {
+            return await _httpClient.SendAsync(message);
+        }
+    }
+}

--- a/Kentico.Kontent.Delivery/Extensions/ServiceCollectionExtensions.cs
+++ b/Kentico.Kontent.Delivery/Extensions/ServiceCollectionExtensions.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IContentLinkResolver, ContentLinkResolver>();
             services.TryAddSingleton<IContentLinkUrlResolver, DefaultContentLinkUrlResolver>();
             services.TryAddSingleton<ITypeProvider, TypeProvider>();
-            services.TryAddSingleton(new HttpClient());
+            services.TryAddSingleton<IDeliveryHttpClient>(new DeliveryHttpClient(new HttpClient()));
             services.TryAddDeliveryInlineContentItemsResolver<object, ReplaceWithWarningAboutRegistrationResolver>();
             services.TryAddDeliveryInlineContentItemsResolver<UnretrievedContentItem, ReplaceWithWarningAboutUnretrievedItemResolver>();
             services.TryAddDeliveryInlineContentItemsResolver<UnknownContentItem, ReplaceWithWarningAboutUnknownItemResolver>();


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #`issue number`

Create a basic Delivery HTTP client that handles all requests against Delivery API.
Now you can use classic ASP.NET Core HTTP Factory and register the Delivery HTTP client into

services.AddHttpClient<IDeliveryHttpClient, DeliveryHttpClient>();

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
